### PR TITLE
Bind to localhost only in order to avoid firewall prompts

### DIFF
--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -64,6 +64,11 @@ public:
     void listen(const port_type port);
 
     /**
+     * Bind and listen to a TCP port on the given endpoint
+     */
+    void listen(const tcp::endpoint endpoint);
+
+    /**
      * Endpoint (IP address and port number) that this server is currently
      * listening on.
      *

--- a/src/connectors/wire/WireServer.cpp
+++ b/src/connectors/wire/WireServer.cpp
@@ -45,7 +45,11 @@ TCPSocketServer::TCPSocketServer(const ProtocolHandler *protocolHandler) :
 }
 
 void TCPSocketServer::listen(const port_type port) {
-    doListen(acceptor, tcp::endpoint(tcp::v4(), port));
+    listen(tcp::endpoint(tcp::v4(), port));
+}
+
+void TCPSocketServer::listen(const tcp::endpoint endpoint) {
+    doListen(acceptor, endpoint);
     acceptor.set_option(tcp::no_delay(true));
 }
 


### PR DESCRIPTION
This little change makes the annoying firewall prompts on Mac OS (probably Windows as well) disappear. It's most likely not upstreamable in this from as this behavior would probably have to be made configurable, so this PR can serve as a place to discuss whether and how to include it.