### PR TITLE
Cherry-pick our workaround patches

### DIFF
--- a/include/cucumber-cpp/internal/ContextManager.hpp
+++ b/include/cucumber-cpp/internal/ContextManager.hpp
@@ -16,7 +16,7 @@ namespace internal {
 
 typedef std::vector<shared_ptr<void> > contexts_type;
 
-class ContextManager {
+class CUCUMBER_CPP_EXPORT ContextManager {
 public:
     void purgeContexts();
     template<class T> weak_ptr<T> addContext();

--- a/include/cucumber-cpp/internal/CukeCommands.hpp
+++ b/include/cucumber-cpp/internal/CukeCommands.hpp
@@ -21,7 +21,7 @@ using boost::shared_ptr;
 /**
  * Legacy class to be removed when feature #31 is complete, substituted by CukeEngineImpl.
  */
-class CukeCommands {
+class CUCUMBER_CPP_EXPORT CukeCommands {
 public:
 	CukeCommands();
 	virtual ~CukeCommands();

--- a/include/cucumber-cpp/internal/CukeEngine.hpp
+++ b/include/cucumber-cpp/internal/CukeEngine.hpp
@@ -9,13 +9,13 @@
 namespace cucumber {
 namespace internal {
 
-class StepMatchArg {
+class CUCUMBER_CPP_EXPORT StepMatchArg {
 public:
     std::string value;
     int position;
 };
 
-class StepMatch {
+class CUCUMBER_CPP_EXPORT StepMatch {
 public:
     std::string id;
     std::vector<StepMatchArg> args;
@@ -23,7 +23,7 @@ public:
     std::string regexp;
 };
 
-class InvokeException {
+class CUCUMBER_CPP_EXPORT InvokeException {
 private:
     const std::string message;
 
@@ -36,7 +36,7 @@ public:
     virtual ~InvokeException() {}
 };
 
-class InvokeFailureException : public InvokeException {
+class CUCUMBER_CPP_EXPORT InvokeFailureException : public InvokeException {
 private:
     const std::string exceptionType;
 
@@ -47,7 +47,7 @@ public:
     const std::string getExceptionType() const;
 };
 
-class PendingStepException : public InvokeException {
+class CUCUMBER_CPP_EXPORT PendingStepException : public InvokeException {
 public:
     PendingStepException(const std::string & message);
     PendingStepException(const PendingStepException &rhs);
@@ -59,7 +59,7 @@ public:
  * It uses standard types (as much as possible) to be easier to call.
  * Returns standard types if possible.
  */
-class CukeEngine {
+class CUCUMBER_CPP_EXPORT CukeEngine {
 private:
     typedef std::vector<std::string> string_array;
     typedef boost::multi_array<std::string, 2> string_2d_array;

--- a/include/cucumber-cpp/internal/CukeEngineImpl.hpp
+++ b/include/cucumber-cpp/internal/CukeEngineImpl.hpp
@@ -13,7 +13,7 @@ namespace internal {
  * Currently it is a wrapper around CukeCommands. It will have its own
  * implementation when feature #31 is complete.
  */
-class CukeEngineImpl : public CukeEngine {
+class CUCUMBER_CPP_EXPORT CukeEngineImpl : public CukeEngine {
 private:
     CukeCommands cukeCommands;
 

--- a/include/cucumber-cpp/internal/Table.hpp
+++ b/include/cucumber-cpp/internal/Table.hpp
@@ -9,7 +9,7 @@
 namespace cucumber {
 namespace internal {
 
-class Table {
+class CUCUMBER_CPP_EXPORT Table {
 private:
     typedef std::vector<std::string> basic_type;
 public:

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -14,7 +14,7 @@ namespace internal {
 
 class WireResponseVisitor;
 
-class WireResponse {
+class CUCUMBER_CPP_EXPORT WireResponse {
 public:
     WireResponse() {};
 
@@ -23,12 +23,12 @@ public:
     virtual ~WireResponse() {};
 };
 
-class SuccessResponse : public WireResponse {
+class CUCUMBER_CPP_EXPORT SuccessResponse : public WireResponse {
 public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class FailureResponse : public WireResponse {
+class CUCUMBER_CPP_EXPORT FailureResponse : public WireResponse {
 private:
     const std::string message, exceptionType;
 
@@ -41,7 +41,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class PendingResponse : public WireResponse {
+class CUCUMBER_CPP_EXPORT PendingResponse : public WireResponse {
 private:
     const std::string message;
 
@@ -53,7 +53,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class StepMatchesResponse : public WireResponse {
+class CUCUMBER_CPP_EXPORT StepMatchesResponse : public WireResponse {
 private:
     const std::vector<StepMatch> matchingSteps;
 
@@ -64,7 +64,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class SnippetTextResponse : public WireResponse {
+class CUCUMBER_CPP_EXPORT SnippetTextResponse : public WireResponse {
 private:
     const std::string stepSnippet;
 
@@ -76,7 +76,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class WireResponseVisitor {
+class CUCUMBER_CPP_EXPORT WireResponseVisitor {
 public:
     virtual void visit(const SuccessResponse& response) = 0;
     virtual void visit(const FailureResponse& response) = 0;
@@ -91,7 +91,7 @@ public:
 /**
  * Wire protocol request command.
  */
-class WireCommand {
+class CUCUMBER_CPP_EXPORT WireCommand {
 public:
     /**
      * Runs the command on the provided engine
@@ -105,7 +105,7 @@ public:
     virtual ~WireCommand() {};
 };
 
-class WireMessageCodecException : public std::exception {
+class CUCUMBER_CPP_EXPORT WireMessageCodecException : public std::exception {
 private:
     const char *description;
 
@@ -123,7 +123,7 @@ public:
 /**
  * Transforms wire messages into commands and responses to messages.
  */
-class WireMessageCodec {
+class CUCUMBER_CPP_EXPORT WireMessageCodec {
 public:
     /**
      * Decodes a wire message into a command.
@@ -151,7 +151,7 @@ public:
 /**
  * WireMessageCodec implementation with JsonSpirit.
  */
-class JsonSpiritWireMessageCodec : public WireMessageCodec {
+class CUCUMBER_CPP_EXPORT JsonSpiritWireMessageCodec : public WireMessageCodec {
 public:
     JsonSpiritWireMessageCodec();
     boost::shared_ptr<WireCommand> decode(const std::string &request) const;
@@ -162,7 +162,7 @@ public:
  * Wire protocol handler, delegating JSON encoding and decoding to a
  * codec object and running commands on a provided engine instance.
  */
-class WireProtocolHandler : public ProtocolHandler {
+class CUCUMBER_CPP_EXPORT WireProtocolHandler : public ProtocolHandler {
 private:
     const WireMessageCodec& codec;
     CukeEngine& engine;

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -19,7 +19,7 @@ using namespace boost::asio::local;
 /**
  * Socket server that calls a protocol handler line by line
  */
-class SocketServer {
+class CUCUMBER_CPP_EXPORT SocketServer {
 public:
     /**
       * Constructor for DI
@@ -46,7 +46,7 @@ protected:
 /**
  * Socket server that calls a protocol handler line by line
  */
-class TCPSocketServer : public SocketServer {
+class CUCUMBER_CPP_EXPORT TCPSocketServer : public SocketServer {
 public:
     /**
      * Type definition for TCP port

--- a/include/cucumber-cpp/internal/drivers/GTestDriver.hpp
+++ b/include/cucumber-cpp/internal/drivers/GTestDriver.hpp
@@ -8,7 +8,7 @@
 namespace cucumber {
 namespace internal {
 
-class GTestStep : public BasicStep {
+class CUCUMBER_CPP_EXPORT GTestStep : public BasicStep {
 protected:
     const InvokeResult invokeStepBody();
 

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -63,6 +63,7 @@ class CUCUMBER_CPP_EXPORT HookRegistrar {
 public:
     typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
     typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
+    typedef bool(*StepMatchingHook)(const boost::cmatch&);
 
     virtual ~HookRegistrar();
 
@@ -84,6 +85,9 @@ public:
     void addAfterAllHook(const boost::shared_ptr<AfterAllHook>& afterAllHook);
     void execAfterAllHooks();
 
+    void setStepMatchingHook(StepMatchingHook hook);
+    bool execStepMatchingHook(const boost::cmatch& originalMatch);
+
 private:
     void execHooks(HookRegistrar::hook_list_type &hookList, Scenario *scenario);
 
@@ -94,6 +98,7 @@ protected:
     hook_list_type& afterStepHooks();
     hook_list_type& afterHooks();
     hook_list_type& afterAllHooks();
+    StepMatchingHook& stepMatchingHook();
 };
 
 

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -14,12 +14,12 @@ using boost::shared_ptr;
 namespace cucumber {
 namespace internal {
 
-class CallableStep {
+class CUCUMBER_CPP_EXPORT CallableStep {
 public:
     virtual void call() = 0;
 };
 
-class Hook {
+class CUCUMBER_CPP_EXPORT Hook {
 public:
     void setTags(const std::string &csvTagNotation);
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
@@ -31,10 +31,10 @@ private:
     shared_ptr<TagExpression> tagExpression;
 };
 
-class BeforeHook : public Hook {
+class CUCUMBER_CPP_EXPORT BeforeHook : public Hook {
 };
 
-class AroundStepHook : public Hook {
+class CUCUMBER_CPP_EXPORT AroundStepHook : public Hook {
 public:
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
     virtual void skipHook();
@@ -42,24 +42,24 @@ protected:
     CallableStep *step;
 };
 
-class AfterStepHook : public Hook {
+class CUCUMBER_CPP_EXPORT AfterStepHook : public Hook {
 };
 
-class AfterHook : public Hook {
+class CUCUMBER_CPP_EXPORT AfterHook : public Hook {
 };
 
-class UnconditionalHook : public Hook {
+class CUCUMBER_CPP_EXPORT UnconditionalHook : public Hook {
 public:
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
 };
 
-class BeforeAllHook : public UnconditionalHook {
+class CUCUMBER_CPP_EXPORT BeforeAllHook : public UnconditionalHook {
 };
 
-class AfterAllHook : public UnconditionalHook {
+class CUCUMBER_CPP_EXPORT AfterAllHook : public UnconditionalHook {
 };
 
-class HookRegistrar {
+class CUCUMBER_CPP_EXPORT HookRegistrar {
 public:
     typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
     typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
@@ -97,7 +97,7 @@ protected:
 };
 
 
-class StepCallChain {
+class CUCUMBER_CPP_EXPORT StepCallChain {
 public:
     StepCallChain(Scenario *scenario, const boost::shared_ptr<const StepInfo>& stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
     InvokeResult exec();
@@ -114,7 +114,7 @@ private:
     InvokeResult result;
 };
 
-class CallableStepChain : public CallableStep {
+class CUCUMBER_CPP_EXPORT CallableStepChain : public CallableStep {
 public:
     CallableStepChain(StepCallChain *scc);
     void call();

--- a/include/cucumber-cpp/internal/hook/Tag.hpp
+++ b/include/cucumber-cpp/internal/hook/Tag.hpp
@@ -12,7 +12,7 @@ using boost::shared_ptr;
 namespace cucumber {
 namespace internal {
 
-class TagExpression {
+class CUCUMBER_CPP_EXPORT TagExpression {
 public:
     typedef std::vector<std::string> tag_list;
 
@@ -20,7 +20,7 @@ public:
     virtual bool matches(const tag_list &tags) = 0;
 };
 
-class OrTagExpression : public TagExpression {
+class CUCUMBER_CPP_EXPORT OrTagExpression : public TagExpression {
 public:
     OrTagExpression(const std::string &csvTagNotation);
     bool matches(const tag_list &tags);
@@ -33,7 +33,7 @@ private:
     static Regex & csvTagNotationRegex();
 };
 
-class AndTagExpression : public TagExpression {
+class CUCUMBER_CPP_EXPORT AndTagExpression : public TagExpression {
 public:
     AndTagExpression(const std::string &csvTagNotation);
     bool matches(const tag_list &tags);

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -22,7 +22,7 @@ typedef unsigned int step_id_type;
 
 class StepInfo;
 
-class SingleStepMatch {
+class CUCUMBER_CPP_EXPORT SingleStepMatch {
 public:
     typedef RegexMatch::submatches_type submatches_type;
 
@@ -33,7 +33,7 @@ public:
 };
 
 
-class MatchResult {
+class CUCUMBER_CPP_EXPORT MatchResult {
 public:
     typedef std::vector<SingleStepMatch> match_results_type;
 
@@ -48,7 +48,7 @@ private:
 };
 
 
-class InvokeArgs {
+class CUCUMBER_CPP_EXPORT InvokeArgs {
     typedef std::vector<std::string> args_type;
 public:
     typedef args_type::size_type size_type;
@@ -71,7 +71,7 @@ enum InvokeResultType {
     PENDING
 };
 
-class InvokeResult {
+class CUCUMBER_CPP_EXPORT InvokeResult {
 private:
     InvokeResultType type;
     std::string description;
@@ -94,7 +94,7 @@ public:
 };
 
 
-class StepInfo : public boost::enable_shared_from_this<StepInfo> {
+class CUCUMBER_CPP_EXPORT StepInfo : public boost::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
     SingleStepMatch matches(const std::string &stepDescription) const;
@@ -109,7 +109,7 @@ private:
 };
 
 
-class BasicStep {
+class CUCUMBER_CPP_EXPORT BasicStep {
 public:
     InvokeResult invoke(const InvokeArgs *pArgs);
 
@@ -143,7 +143,7 @@ public:
 };
 
 
-class StepManager {
+class CUCUMBER_CPP_EXPORT StepManager {
 protected:
     typedef std::map<step_id_type, boost::shared_ptr<const StepInfo> > steps_type;
 

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -128,6 +128,19 @@ void HookRegistrar::execAfterAllHooks() {
     execHooks(afterAllHooks(), NULL);
 }
 
+void HookRegistrar::setStepMatchingHook(StepMatchingHook hook) {
+    stepMatchingHook() = hook;
+}
+
+bool HookRegistrar::execStepMatchingHook(const boost::cmatch& originalMatch) {
+    return stepMatchingHook() == nullptr || stepMatchingHook()(originalMatch);
+}
+
+HookRegistrar::StepMatchingHook& HookRegistrar::stepMatchingHook() {
+    static StepMatchingHook stepMatchingHook = nullptr;
+    return stepMatchingHook;
+}
+
 
 StepCallChain::StepCallChain(
     Scenario *scenario,

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,3 +1,4 @@
+#include <cucumber-cpp/internal/hook/HookRegistrar.hpp>
 #include <cucumber-cpp/internal/utils/Regex.hpp>
 #include <boost/make_shared.hpp>
 
@@ -26,7 +27,9 @@ boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
 
 FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
     boost::cmatch matchResults;
-    regexMatched = boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra);
+    regexMatched =
+        boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra)
+            && HookRegistrar().execStepMatchingHook(matchResults);
     if (regexMatched) {
         for (boost::cmatch::size_type i = 1; i < matchResults.size(); ++i) {
             RegexSubmatch s;


### PR DESCRIPTION
This PR basically just brings the `ableton-master` to the same point as the old `nre_master_ableton-octo` branch (which lives on under the tag name `ableton-initial-migration`). The only difference is that I've cleaned up the commit messages a bit.

ping @ala-ableton 