### PR TITLE
Merge commits used by live.git into default branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "features/cucumber-tck"]
 	path = features/cucumber-tck
-	url = git://github.com/cucumber/cucumber-tck.git
+	url = https://github.com/cucumber/cucumber-tck.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(Cucumber-Cpp)
 
 set(CUKE_USE_STATIC_BOOST ${WIN32} CACHE BOOL "Statically link Boost (except boost::test)")
 set(CUKE_USE_STATIC_GTEST ON CACHE BOOL "Statically link Google Test")
+set(CUKE_ENABLE_SHARED_LIB OFF CACHE BOOL "Generate a shared library")
 
 set(CUKE_DISABLE_BOOST_TEST OFF CACHE BOOL "Disable boost:test")
 set(CUKE_DISABLE_GTEST OFF CACHE BOOL "Disable Google Test framework")

--- a/include/cucumber-cpp/internal/ContextManager.hpp
+++ b/include/cucumber-cpp/internal/ContextManager.hpp
@@ -1,6 +1,8 @@
 #ifndef CUKE_CONTEXTMANAGER_HPP_
 #define CUKE_CONTEXTMANAGER_HPP_
 
+#include "CukeDll.hpp"
+
 #include <vector>
 
 #include <boost/make_shared.hpp>
@@ -16,7 +18,7 @@ namespace internal {
 
 typedef std::vector<shared_ptr<void> > contexts_type;
 
-class ContextManager {
+class CUKE_API_ ContextManager {
 public:
     void purgeContexts();
     template<class T> weak_ptr<T> addContext();

--- a/include/cucumber-cpp/internal/CukeCommands.hpp
+++ b/include/cucumber-cpp/internal/CukeCommands.hpp
@@ -2,6 +2,7 @@
 #define CUKE_CUKECOMMANDS_HPP_
 
 #include "ContextManager.hpp"
+#include "CukeDll.hpp"
 #include "Scenario.hpp"
 #include "Table.hpp"
 #include "step/StepManager.hpp"
@@ -21,7 +22,7 @@ using boost::shared_ptr;
 /**
  * Legacy class to be removed when feature #31 is complete, substituted by CukeEngineImpl.
  */
-class CukeCommands {
+class CUKE_API_ CukeCommands {
 public:
 	CukeCommands();
 	virtual ~CukeCommands();

--- a/include/cucumber-cpp/internal/CukeDll.hpp
+++ b/include/cucumber-cpp/internal/CukeDll.hpp
@@ -1,0 +1,14 @@
+#ifndef CUKE_CUKEDLL_HPP_
+#define CUKE_CUKEDLL_HPP_
+
+#ifndef CUKE_API_
+#if CUKE_LINKED_AS_SHARED_LIBRARY
+#define CUKE_API_ __declspec(dllimport)
+#elif CUKE_CREATE_SHARED_LIBRARY
+#define CUKE_API_ __declspec(dllexport)
+#else
+#define CUKE_API_
+#endif
+#endif
+
+#endif /* CUKE_CUKEDLL_HPP_ */

--- a/include/cucumber-cpp/internal/CukeEngine.hpp
+++ b/include/cucumber-cpp/internal/CukeEngine.hpp
@@ -1,6 +1,8 @@
 #ifndef CUKE_CUKEENGINE_HPP_
 #define CUKE_CUKEENGINE_HPP_
 
+#include "CukeDll.hpp"
+
 #include <string>
 #include <vector>
 
@@ -9,13 +11,13 @@
 namespace cucumber {
 namespace internal {
 
-class StepMatchArg {
+class CUKE_API_ StepMatchArg {
 public:
     std::string value;
     int position;
 };
 
-class StepMatch {
+class CUKE_API_ StepMatch {
 public:
     std::string id;
     std::vector<StepMatchArg> args;
@@ -23,7 +25,7 @@ public:
     std::string regexp;
 };
 
-class InvokeException {
+class CUKE_API_ InvokeException {
 private:
     const std::string message;
 
@@ -36,7 +38,7 @@ public:
     virtual ~InvokeException() {}
 };
 
-class InvokeFailureException : public InvokeException {
+class CUKE_API_ InvokeFailureException : public InvokeException {
 private:
     const std::string exceptionType;
 
@@ -47,7 +49,7 @@ public:
     const std::string getExceptionType() const;
 };
 
-class PendingStepException : public InvokeException {
+class CUKE_API_ PendingStepException : public InvokeException {
 public:
     PendingStepException(const std::string & message);
     PendingStepException(const PendingStepException &rhs);
@@ -59,7 +61,7 @@ public:
  * It uses standard types (as much as possible) to be easier to call.
  * Returns standard types if possible.
  */
-class CukeEngine {
+class CUKE_API_ CukeEngine {
 private:
     typedef std::vector<std::string> string_array;
     typedef boost::multi_array<std::string, 2> string_2d_array;

--- a/include/cucumber-cpp/internal/CukeEngineImpl.hpp
+++ b/include/cucumber-cpp/internal/CukeEngineImpl.hpp
@@ -13,7 +13,7 @@ namespace internal {
  * Currently it is a wrapper around CukeCommands. It will have its own
  * implementation when feature #31 is complete.
  */
-class CukeEngineImpl : public CukeEngine {
+class CUKE_API_ CukeEngineImpl : public CukeEngine {
 private:
     CukeCommands cukeCommands;
 

--- a/include/cucumber-cpp/internal/Table.hpp
+++ b/include/cucumber-cpp/internal/Table.hpp
@@ -1,6 +1,8 @@
 #ifndef CUKE_TABLE_HPP_
 #define CUKE_TABLE_HPP_
 
+#include "CukeDll.hpp"
+
 #include <vector>
 #include <map>
 #include <string>
@@ -9,7 +11,7 @@
 namespace cucumber {
 namespace internal {
 
-class Table {
+class CUKE_API_ Table {
 private:
     typedef std::vector<std::string> basic_type;
 public:

--- a/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireProtocol.hpp
@@ -2,6 +2,7 @@
 #define CUKE_WIREPROTOCOL_HPP_
 
 #include "ProtocolHandler.hpp"
+#include "../../CukeDll.hpp"
 #include "../../CukeEngine.hpp"
 #include <boost/shared_ptr.hpp>
 
@@ -14,7 +15,7 @@ namespace internal {
 
 class WireResponseVisitor;
 
-class WireResponse {
+class CUKE_API_ WireResponse {
 public:
     WireResponse() {};
 
@@ -23,12 +24,12 @@ public:
     virtual ~WireResponse() {};
 };
 
-class SuccessResponse : public WireResponse {
+class CUKE_API_ SuccessResponse : public WireResponse {
 public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class FailureResponse : public WireResponse {
+class CUKE_API_ FailureResponse : public WireResponse {
 private:
     const std::string message, exceptionType;
 
@@ -41,7 +42,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class PendingResponse : public WireResponse {
+class CUKE_API_ PendingResponse : public WireResponse {
 private:
     const std::string message;
 
@@ -53,7 +54,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class StepMatchesResponse : public WireResponse {
+class CUKE_API_ StepMatchesResponse : public WireResponse {
 private:
     const std::vector<StepMatch> matchingSteps;
 
@@ -64,7 +65,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class SnippetTextResponse : public WireResponse {
+class CUKE_API_ SnippetTextResponse : public WireResponse {
 private:
     const std::string stepSnippet;
 
@@ -76,7 +77,7 @@ public:
     void accept(WireResponseVisitor& visitor) const;
 };
 
-class WireResponseVisitor {
+class CUKE_API_ WireResponseVisitor {
 public:
     virtual void visit(const SuccessResponse& response) = 0;
     virtual void visit(const FailureResponse& response) = 0;
@@ -91,7 +92,7 @@ public:
 /**
  * Wire protocol request command.
  */
-class WireCommand {
+class CUKE_API_ WireCommand {
 public:
     /**
      * Runs the command on the provided engine
@@ -105,7 +106,7 @@ public:
     virtual ~WireCommand() {};
 };
 
-class WireMessageCodecException : public std::exception {
+class CUKE_API_ WireMessageCodecException : public std::exception {
 private:
     const char *description;
 
@@ -123,7 +124,7 @@ public:
 /**
  * Transforms wire messages into commands and responses to messages.
  */
-class WireMessageCodec {
+class CUKE_API_ WireMessageCodec {
 public:
     /**
      * Decodes a wire message into a command.
@@ -151,7 +152,7 @@ public:
 /**
  * WireMessageCodec implementation with JsonSpirit.
  */
-class JsonSpiritWireMessageCodec : public WireMessageCodec {
+class CUKE_API_ JsonSpiritWireMessageCodec : public WireMessageCodec {
 public:
     JsonSpiritWireMessageCodec();
     boost::shared_ptr<WireCommand> decode(const std::string &request) const;
@@ -162,7 +163,7 @@ public:
  * Wire protocol handler, delegating JSON encoding and decoding to a
  * codec object and running commands on a provided engine instance.
  */
-class WireProtocolHandler : public ProtocolHandler {
+class CUKE_API_ WireProtocolHandler : public ProtocolHandler {
 private:
     const WireMessageCodec& codec;
     CukeEngine& engine;

--- a/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
+++ b/include/cucumber-cpp/internal/connectors/wire/WireServer.hpp
@@ -2,6 +2,7 @@
 #define CUKE_WIRESERVER_HPP_
 
 #include "ProtocolHandler.hpp"
+#include "../../CukeDll.hpp"
 
 #include <string>
 
@@ -19,7 +20,7 @@ using namespace boost::asio::local;
 /**
  * Socket server that calls a protocol handler line by line
  */
-class SocketServer {
+class CUKE_API_ SocketServer {
 public:
     /**
       * Constructor for DI
@@ -46,7 +47,7 @@ protected:
 /**
  * Socket server that calls a protocol handler line by line
  */
-class TCPSocketServer : public SocketServer {
+class CUKE_API_ TCPSocketServer : public SocketServer {
 public:
     /**
      * Type definition for TCP port

--- a/include/cucumber-cpp/internal/defs.hpp
+++ b/include/cucumber-cpp/internal/defs.hpp
@@ -1,5 +1,6 @@
 #include "step/StepManager.hpp"
 #include "hook/HookRegistrar.hpp"
 #include "ContextManager.hpp"
+#include "CukeDll.hpp"
 #include "Macros.hpp"
 #include "drivers/DriverSelector.hpp"

--- a/include/cucumber-cpp/internal/drivers/GTestDriver.hpp
+++ b/include/cucumber-cpp/internal/drivers/GTestDriver.hpp
@@ -1,6 +1,7 @@
 #ifndef CUKE_GTESTDRIVER_HPP_
 #define CUKE_GTESTDRIVER_HPP_
 
+#include "../CukeDll.hpp"
 #include "../step/StepManager.hpp"
 
 #include <iostream>
@@ -8,7 +9,7 @@
 namespace cucumber {
 namespace internal {
 
-class GTestStep : public BasicStep {
+class CUKE_API_ GTestStep : public BasicStep {
 protected:
     const InvokeResult invokeStepBody();
 

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -2,6 +2,7 @@
 #define CUKE_HOOKREGISTRAR_HPP_
 
 #include "Tag.hpp"
+#include "../CukeDll.hpp"
 #include "../Scenario.hpp"
 #include "../step/StepManager.hpp"
 
@@ -14,12 +15,12 @@ using boost::shared_ptr;
 namespace cucumber {
 namespace internal {
 
-class CallableStep {
+class CUKE_API_ CallableStep {
 public:
     virtual void call() = 0;
 };
 
-class Hook {
+class CUKE_API_ Hook {
 public:
     void setTags(const std::string &csvTagNotation);
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
@@ -31,10 +32,10 @@ private:
     shared_ptr<TagExpression> tagExpression;
 };
 
-class BeforeHook : public Hook {
+class CUKE_API_ BeforeHook : public Hook {
 };
 
-class AroundStepHook : public Hook {
+class CUKE_API_ AroundStepHook : public Hook {
 public:
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
     virtual void skipHook();
@@ -42,24 +43,24 @@ protected:
     CallableStep *step;
 };
 
-class AfterStepHook : public Hook {
+class CUKE_API_ AfterStepHook : public Hook {
 };
 
-class AfterHook : public Hook {
+class CUKE_API_ AfterHook : public Hook {
 };
 
-class UnconditionalHook : public Hook {
+class CUKE_API_ UnconditionalHook : public Hook {
 public:
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
 };
 
-class BeforeAllHook : public UnconditionalHook {
+class CUKE_API_ BeforeAllHook : public UnconditionalHook {
 };
 
-class AfterAllHook : public UnconditionalHook {
+class CUKE_API_ AfterAllHook : public UnconditionalHook {
 };
 
-class HookRegistrar {
+class CUKE_API_ HookRegistrar {
 public:
     typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
     typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
@@ -97,7 +98,7 @@ protected:
 };
 
 
-class StepCallChain {
+class CUKE_API_ StepCallChain {
 public:
     StepCallChain(Scenario *scenario, const boost::shared_ptr<const StepInfo>& stepInfo, const InvokeArgs *pStepArgs, HookRegistrar::aroundhook_list_type &aroundHooks);
     InvokeResult exec();
@@ -114,7 +115,7 @@ private:
     InvokeResult result;
 };
 
-class CallableStepChain : public CallableStep {
+class CUKE_API_ CallableStepChain : public CallableStep {
 public:
     CallableStepChain(StepCallChain *scc);
     void call();

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -64,6 +64,7 @@ class CUKE_API_ HookRegistrar {
 public:
     typedef std::list< boost::shared_ptr<Hook> > hook_list_type;
     typedef std::list< boost::shared_ptr<AroundStepHook> > aroundhook_list_type;
+    typedef bool(*StepMatchingHook)(const boost::cmatch&);
 
     virtual ~HookRegistrar();
 
@@ -85,6 +86,9 @@ public:
     void addAfterAllHook(const boost::shared_ptr<AfterAllHook>& afterAllHook);
     void execAfterAllHooks();
 
+    void setStepMatchingHook(StepMatchingHook hook);
+    bool execStepMatchingHook(const boost::cmatch& originalMatch);
+
 private:
     void execHooks(HookRegistrar::hook_list_type &hookList, Scenario *scenario);
 
@@ -95,6 +99,7 @@ protected:
     hook_list_type& afterStepHooks();
     hook_list_type& afterHooks();
     hook_list_type& afterAllHooks();
+    StepMatchingHook& stepMatchingHook();
 };
 
 

--- a/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
+++ b/include/cucumber-cpp/internal/hook/HookRegistrar.hpp
@@ -17,11 +17,13 @@ namespace internal {
 
 class CUKE_API_ CallableStep {
 public:
+    virtual ~CallableStep() = 0;
     virtual void call() = 0;
 };
 
 class CUKE_API_ Hook {
 public:
+    virtual ~Hook() = 0;
     void setTags(const std::string &csvTagNotation);
     virtual void invokeHook(Scenario *scenario, CallableStep *step);
     virtual void skipHook();

--- a/include/cucumber-cpp/internal/hook/Tag.hpp
+++ b/include/cucumber-cpp/internal/hook/Tag.hpp
@@ -7,12 +7,13 @@
 #include <boost/shared_ptr.hpp>
 using boost::shared_ptr;
 
+#include "../CukeDll.hpp"
 #include "../utils/Regex.hpp"
 
 namespace cucumber {
 namespace internal {
 
-class TagExpression {
+class CUKE_API_ TagExpression {
 public:
     typedef std::vector<std::string> tag_list;
 
@@ -20,7 +21,7 @@ public:
     virtual bool matches(const tag_list &tags) = 0;
 };
 
-class OrTagExpression : public TagExpression {
+class CUKE_API_ OrTagExpression : public TagExpression {
 public:
     OrTagExpression(const std::string &csvTagNotation);
     bool matches(const tag_list &tags);
@@ -33,7 +34,7 @@ private:
     static Regex & csvTagNotationRegex();
 };
 
-class AndTagExpression : public TagExpression {
+class CUKE_API_ AndTagExpression : public TagExpression {
 public:
     AndTagExpression(const std::string &csvTagNotation);
     bool matches(const tag_list &tags);

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -12,6 +12,7 @@
 #include <boost/shared_ptr.hpp>
 using boost::shared_ptr;
 
+#include "../CukeDll.hpp"
 #include "../Table.hpp"
 #include "../utils/Regex.hpp"
 
@@ -22,7 +23,7 @@ typedef unsigned int step_id_type;
 
 class StepInfo;
 
-class SingleStepMatch {
+class CUKE_API_ SingleStepMatch {
 public:
     typedef RegexMatch::submatches_type submatches_type;
 
@@ -33,7 +34,7 @@ public:
 };
 
 
-class MatchResult {
+class CUKE_API_ MatchResult {
 public:
     typedef std::vector<SingleStepMatch> match_results_type;
 
@@ -48,7 +49,7 @@ private:
 };
 
 
-class InvokeArgs {
+class CUKE_API_ InvokeArgs {
     typedef std::vector<std::string> args_type;
 public:
     typedef args_type::size_type size_type;
@@ -71,7 +72,7 @@ enum InvokeResultType {
     PENDING
 };
 
-class InvokeResult {
+class CUKE_API_ InvokeResult {
 private:
     InvokeResultType type;
     std::string description;
@@ -94,7 +95,7 @@ public:
 };
 
 
-class StepInfo : public boost::enable_shared_from_this<StepInfo> {
+class CUKE_API_ StepInfo : public boost::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
     SingleStepMatch matches(const std::string &stepDescription) const;
@@ -109,7 +110,7 @@ private:
 };
 
 
-class BasicStep {
+class CUKE_API_ BasicStep {
 public:
     InvokeResult invoke(const InvokeArgs *pArgs);
 
@@ -143,7 +144,7 @@ public:
 };
 
 
-class StepManager {
+class CUKE_API_ StepManager {
 protected:
     typedef std::map<step_id_type, boost::shared_ptr<const StepInfo> > steps_type;
 

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -53,9 +53,9 @@ class CUKE_API_ InvokeArgs {
     typedef std::vector<std::string> args_type;
 public:
     typedef args_type::size_type size_type;
-    
+
     InvokeArgs() { }
- 
+
     void addArg(const std::string arg);
     Table & getVariableTableArg();
 
@@ -106,7 +106,6 @@ public:
     const std::string source;
 private:
     StepInfo& operator=(const StepInfo& other);
-    
 };
 
 

--- a/include/cucumber-cpp/internal/step/StepManager.hpp
+++ b/include/cucumber-cpp/internal/step/StepManager.hpp
@@ -98,6 +98,7 @@ public:
 class CUKE_API_ StepInfo : public boost::enable_shared_from_this<StepInfo> {
 public:
     StepInfo(const std::string &stepMatcher, const std::string source);
+    virtual ~StepInfo() = 0;
     SingleStepMatch matches(const std::string &stepDescription) const;
     virtual InvokeResult invokeStep(const InvokeArgs * pArgs) const = 0;
 
@@ -111,6 +112,7 @@ private:
 
 class CUKE_API_ BasicStep {
 public:
+    virtual ~BasicStep() = 0;
     InvokeResult invoke(const InvokeArgs *pArgs);
 
 protected:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,14 @@ if(CMAKE_EXTRA_GENERATOR OR MSVC_IDE)
     list(APPEND CUKE_SOURCES ${CUKE_HEADERS})
 endif()
 
-add_library(cucumber-cpp-nomain STATIC ${CUKE_SOURCES})
-add_library(cucumber-cpp STATIC ${CUKE_SOURCES} main.cpp)
+if(CUKE_ENABLE_SHARED_LIB)
+  set(CUKE_LINKAGE SHARED)
+else()
+  set(CUKE_LINKAGE STATIC)
+endif()
+
+add_library(cucumber-cpp-nomain ${CUKE_LINKAGE} ${CUKE_SOURCES})
+add_library(cucumber-cpp ${CUKE_LINKAGE} ${CUKE_SOURCES} main.cpp)
 
 if(MINGW)
     list(APPEND CUKE_DEP_LIBRARIES ws2_32)

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -95,7 +95,6 @@ void HookRegistrar::execAfterHooks(Scenario *scenario) {
     execHooks(afterHooks(), scenario);
 }
 
-
 void HookRegistrar::execHooks(HookRegistrar::hook_list_type &hookList, Scenario *scenario) {
     for (HookRegistrar::hook_list_type::iterator hook = hookList.begin(); hook != hookList.end(); ++hook) {
         (*hook)->invokeHook(scenario, NULL);
@@ -126,6 +125,19 @@ void HookRegistrar::addAfterAllHook(const boost::shared_ptr<AfterAllHook>& after
 
 void HookRegistrar::execAfterAllHooks() {
     execHooks(afterAllHooks(), NULL);
+}
+
+void HookRegistrar::setStepMatchingHook(StepMatchingHook hook) {
+    stepMatchingHook() = hook;
+}
+
+bool HookRegistrar::execStepMatchingHook(const boost::cmatch& originalMatch) {
+    return stepMatchingHook() == nullptr || stepMatchingHook()(originalMatch);
+}
+
+HookRegistrar::StepMatchingHook& HookRegistrar::stepMatchingHook() {
+    static StepMatchingHook stepMatchingHook = nullptr;
+    return stepMatchingHook;
 }
 
 

--- a/src/HookRegistrar.cpp
+++ b/src/HookRegistrar.cpp
@@ -5,6 +5,12 @@
 namespace cucumber {
 namespace internal {
 
+CallableStep::~CallableStep() {
+}
+
+Hook::~Hook() {
+}
+
 void Hook::invokeHook(Scenario *scenario, CallableStep *) {
     if (tagsMatch(scenario)) {
         body();

--- a/src/Regex.cpp
+++ b/src/Regex.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/utils/Regex.hpp>
+#include <cucumber-cpp/internal/hook/HookRegistrar.hpp>
 #include <boost/make_shared.hpp>
 
 namespace cucumber {
@@ -26,7 +27,8 @@ boost::shared_ptr<RegexMatch> Regex::find(const std::string &expression) const {
 
 FindRegexMatch::FindRegexMatch(const boost::regex &regexImpl, const std::string &expression) {
     boost::cmatch matchResults;
-    regexMatched = boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra);
+    regexMatched = boost::regex_search(expression.c_str(), matchResults, regexImpl, boost::regex_constants::match_extra)
+                   && HookRegistrar().execStepMatchingHook(matchResults);
     if (regexMatched) {
         for (boost::cmatch::size_type i = 1; i < matchResults.size(); ++i) {
             RegexSubmatch s;

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -11,6 +11,7 @@ StepInfo::StepInfo(const std::string &stepMatcher, const std::string source) :
     id = ++currentId;
 }
 
+
 SingleStepMatch StepInfo::matches(const std::string &stepDescription) const {
     SingleStepMatch stepMatch;
     shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
@@ -178,4 +179,3 @@ const InvokeArgs *BasicStep::getArgs() {
 
 }
 }
-

--- a/src/StepManager.cpp
+++ b/src/StepManager.cpp
@@ -12,6 +12,10 @@ StepInfo::StepInfo(const std::string &stepMatcher, const std::string source) :
 }
 
 
+StepInfo::~StepInfo() {
+}
+
+
 SingleStepMatch StepInfo::matches(const std::string &stepDescription) const {
     SingleStepMatch stepMatch;
     shared_ptr<RegexMatch> regexMatch(regex.find(stepDescription));
@@ -139,6 +143,10 @@ const boost::shared_ptr<const StepInfo>& StepManager::getStep(step_id_type id) {
 StepManager::steps_type& StepManager::steps() const {
     static steps_type steps;
     return steps;
+}
+
+
+BasicStep::~BasicStep() {
 }
 
 


### PR DESCRIPTION
Resolves https://github.com/AbletonAppDev/devtools/issues/440.

AbletonAppDev/cucumber-cpp was added to live.git on commit dae8bc9,
which was not on the default branch of AbletonAppDev/cucumber-cpp. To
prevent losing that commit and its parent, we tagged it
"ableton-initial-migration".

Then, AbletonAppDev/cucumber-cpp was updated in live.git to commit
ee57c32, which was still not on the default branch. We tagged it
"build-with-xcode-10".

The best way to preserve these commits is to make them part of the
default branch of AbletonAppDev/cucumber-cpp (which is currently `ableton-master`).

In order to merge that PR I will disable `verboten`, since 609bb41 starts with the forbidden string "WIP".