### PR TITLE
Improve exception propagation in InvokeCommand and CukeEngineImpl

### DIFF
--- a/src/CukeEngineImpl.cpp
+++ b/src/CukeEngineImpl.cpp
@@ -74,6 +74,8 @@ void CukeEngineImpl::invokeStep(const std::string & id, const invoke_args_type &
     InvokeResult commandResult;
     try {
         commandResult = cukeCommands.invoke(convertId(id), &commandArgs);
+    } catch (const std::runtime_error& e) {
+        throw InvokeFailureException(e.what(), "");
     } catch (...) {
         throw InvokeException("Uncatched exception");
     }

--- a/src/connectors/wire/WireProtocolCommands.cpp
+++ b/src/connectors/wire/WireProtocolCommands.cpp
@@ -1,4 +1,5 @@
 #include <cucumber-cpp/internal/connectors/wire/WireProtocolCommands.hpp>
+#include <cucumber-cpp/internal/CukeEngine.hpp>
 #include <boost/make_shared.hpp>
 
 namespace cucumber {
@@ -55,6 +56,8 @@ boost::shared_ptr<WireResponse> InvokeCommand::run(CukeEngine& engine) const {
         return boost::make_shared<FailureResponse>(e.getMessage(), e.getExceptionType());
     } catch (const PendingStepException& e) {
         return boost::make_shared<PendingResponse>(e.getMessage());
+    } catch (const InvokeException& e) {
+        return boost::make_shared<FailureResponse>(e.getMessage(), "InvokeException");
     } catch (...) {
         return boost::make_shared<FailureResponse>();
     }


### PR DESCRIPTION


## Summary

Improve error handling so that exception messages aren't lost.

## Details

Previously, any exception escaping cukeCommands.invoke() that was not an InvokeFailureException or PendingStepException would be silently swallowed in one of two ways:

- In CukeEngineImpl, the catch(...) around cukeCommands.invoke() replaced the original exception with a generic InvokeException carrying only the string "Uncatched exception", discarding the original message.

- In InvokeCommand, InvokeException (the base class) was not caught at all, so it fell through to catch(...) and produced a FailureResponse with no message -- showing up in test output as a bare ["fail"] with no explanation.

The root cause that exposed this: AROUND_STEP hooks in Live's test harness run outside GTestDriver::invokeStepBody()'s try/catch. When an EXPECT_*/ASSERT_* fires in an around hook (e.g. SValidateScriptingEngine()), the resulting
GoogleTestFailureException (a std::runtime_error subclass) escapes the GTest driver and hits CukeEngineImpl's catch(...), where its message was lost.

Fix:
- CukeEngineImpl: catch std::runtime_error explicitly and rethrow as InvokeFailureException so the message is preserved and reported as a proper step failure.
- InvokeCommand: catch InvokeException (base class) and convert it to a FailureResponse with its message, so failures originating in CukeEngineImpl itself are also reported meaningfully.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] It is my own work, its copyright is implicitly assigned to the project and no substantial part of it has been copied from other sources (including [Stack Overflow](https://stackoverflow.com/)). In rare occasions this is acceptable, like in CMake modules where the original copyright information should be kept.
- [ ] I'm using the same code standards as the existing code (indentation, spacing, variable naming, ...).
- [ ] I've added tests for my code.
- [ ] I have verified whether my change requires changes to the documentation
- [ ] My change either requires no documentation change or I've updated the documentation accordingly.
- [ ] My branch has been rebased to main, keeping only relevant commits.
